### PR TITLE
Refactor user loader and add posts/replies APIPosts api refactor

### DIFF
--- a/flask_app/app/extensions.py
+++ b/flask_app/app/extensions.py
@@ -3,3 +3,11 @@ from flask_login import LoginManager
 
 db = SQLAlchemy()
 login_manager = LoginManager()
+
+@login_manager.user_loader
+
+def load_user(id):
+
+    from app.models import User
+
+    return User.query.get(int(id))

--- a/flask_app/app/models.py
+++ b/flask_app/app/models.py
@@ -1,46 +1,46 @@
 from datetime import datetime
 from flask_login import UserMixin
-from .extensions import db
-
-
-class Category(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(50), unique=True, nullable=False)
-    posts = db.relationship("Post", backref="category", lazy=True)
-
-    def to_dict(self):
-        return {"id": self.id, "name": self.name}
-
+from werkzeug.security import generate_password_hash, check_password_hash
+from app.extensions import db
 
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(80), unique=True, nullable=False)
+    username = db.Column(db.String(64), index=True, unique=True)
     password_hash = db.Column(db.String(128))
-    posts = db.relationship("Post", backref="author", lazy=True)
-    replies = db.relationship("Reply", backref="author", lazy=True)
+    
+    posts = db.relationship("Post", backref="author", lazy="dynamic")
+    replies = db.relationship("Reply", backref="author", lazy="dynamic")
 
     def set_password(self, password):
-        from werkzeug.security import generate_password_hash
-
         self.password_hash = generate_password_hash(password)
 
     def check_password(self, password):
-        from werkzeug.security import check_password_hash
-
         return check_password_hash(self.password_hash, password)
 
     def to_dict(self):
         return {"id": self.id, "username": self.username}
 
 
+class Category(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(64), unique=True)
+    
+    posts = db.relationship("Post", backref="category", lazy="dynamic")
+
+    def to_dict(self):
+        return {"id": self.id, "name": self.name}
+
+
 class Post(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    title = db.Column(db.String(200), nullable=False)
-    content = db.Column(db.Text, nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    category_id = db.Column(db.Integer, db.ForeignKey("category.id"), nullable=False)
-    replies = db.relationship("Reply", backref="post", lazy=True)
+    title = db.Column(db.String(140))
+    content = db.Column(db.Text)
+    timestamp = db.Column(db.DateTime, index=True, default=datetime.utcnow)
+    
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"))
+    category_id = db.Column(db.Integer, db.ForeignKey("category.id"))
+    
+    replies = db.relationship("Reply", backref="post", lazy="dynamic")
 
     def to_dict(self):
         return {
@@ -48,23 +48,28 @@ class Post(db.Model):
             "title": self.title,
             "content": self.content,
             "timestamp": self.timestamp.isoformat(),
-            "author": self.author.to_dict(),
-            "category": self.category.to_dict(),
-            "replies": [reply.to_dict() for reply in self.replies],
+            "user_id": self.user_id,
+            "category_id": self.category_id,
+            "author": self.author.to_dict() if self.author else None,
+            "category": self.category.to_dict() if self.category else None,
+            "replies": [reply.to_dict() for reply in self.replies]
         }
 
 
 class Reply(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    content = db.Column(db.Text, nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
+    content = db.Column(db.Text)
+    timestamp = db.Column(db.DateTime, index=True, default=datetime.utcnow)
+    
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"))
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"))
 
     def to_dict(self):
         return {
             "id": self.id,
             "content": self.content,
             "timestamp": self.timestamp.isoformat(),
-            "author": self.author.to_dict(),
+            "user_id": self.user_id,
+            "post_id": self.post_id,
+            "author": self.author.to_dict() if self.author else None
         }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -75,3 +75,14 @@ def test_forgot_password(client, monkeypatch):
     })
     assert response.status_code == 200
     assert "message" in response.get_json()
+def test_create_post(auth_client, category):
+    response = auth_client.post("/posts", json={
+        "title": "Test Post",
+        "content": "This is a test post.",
+        "category_id": category.id
+    })
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["title"] == "Test Post"
+    assert data["category"]["id"] == category.id


### PR DESCRIPTION
- Moved @login_manager.user_loader to extensions.py for better separation of concerns

- Removed the loader logic from __init__.py

- Replaced models.py with updated definitions for User, Post, Reply, and Category

- Added to_dict() methods for JSON serialization

- Defined relationships between users, posts, replies, and categories

- Created a new posts.py blueprint with routes for:

- GET /posts: Fetch all posts (optionally filtered by category)

- GET /posts/<post_id>: Fetch a single post with nested replies

- POST /posts: Create a new post (requires authentication)

- POST /posts/<post_id>/replies: Reply to a post (requires authentication)

- Uses @login_required and current_user to restrict write action